### PR TITLE
Live Chart pokazuje teraz cały kształt wykresu.

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -21,7 +21,7 @@ namespace CTP
             string FileContentRaw = FilePicker.GetFileContent(FilePath);
 
             Measurements data = Measurements.GetInstance();
-            data.SetDataTable(Parser.Parse(FileContentRaw));
+            data.SetDataTable(DataScaler.ScaleData(Parser.Parse(FileContentRaw)));
 
             /*Trace.WriteLine(String.Join(", ", _timeValues));*/
         }

--- a/core/DataScaler.cs
+++ b/core/DataScaler.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Reflection.Metadata.Ecma335;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CTP.core
+{
+    internal class DataScaler
+    {
+        public DataScaler() { }
+
+        // default argument jest tymczasowo, do poprawienia
+        public static DataTable ScaleData(DataTable OriginalData, int TargetDatapoints = 250)
+        {
+
+            decimal OriginalDataPointsCount = OriginalData.Rows.Count;
+
+            decimal OriginalDtPtsPerNewDataPt = Math.Floor(OriginalDataPointsCount/(TargetDatapoints));
+
+            decimal LeftoverDataPoints = 0;
+
+            // dzielenie przez TargetDatapoints jest bez reszty
+            if (OriginalDtPtsPerNewDataPt != (OriginalDataPointsCount/TargetDatapoints))
+            {
+                LeftoverDataPoints = OriginalDataPointsCount - (TargetDatapoints * OriginalDtPtsPerNewDataPt);
+            }
+
+            DataTable newDataTable = new DataTable();
+
+            for (int i = 0; i < OriginalData.Columns.Count; i++)
+            {
+                newDataTable.Columns.Add(OriginalData.Columns[i].ColumnName, typeof(double));
+            }
+
+            //robimy tablice do liczenia srednich i czyscimy ja
+            double[] newValues = new double[newDataTable.Columns.Count];
+            for (int i = 0; i < newDataTable.Columns.Count; i++) newValues[i] = 0;
+
+
+            for (int j = 0; j < TargetDatapoints; j++)
+            {
+                DataRow datarow = newDataTable.NewRow();
+
+                for (int k = 0; k < OriginalData.Columns.Count; k++)
+                {
+                    for (int  l = 0; l < OriginalDtPtsPerNewDataPt; l++)
+                    {
+                        // ta super matma w indeksie sprawi ze przelecimy przez prawie wszystkie elementy DataTable oryginalnego
+                        // nie liczac reszty z dzielenia przez te 250 na poczatku
+                        newValues[k] += OriginalData.Rows[l + j * (int)OriginalDtPtsPerNewDataPt].Field<double>(k);
+                    }
+
+                    newValues[k] = newValues[k] / (double)OriginalDtPtsPerNewDataPt;
+
+                }
+
+                // nie wiem czemu ItemArray nie akceptuje double[] tylko object[]
+                // wiec zamieniam jedno w drugie xd
+
+                object[] rowarr = new object[newValues.Length];
+
+                for (int i = 0; i < newValues.Length; i++)
+                {
+                    rowarr[i] = newValues[i];
+                }
+
+                datarow.ItemArray = rowarr;
+
+                newDataTable.Rows.Add(datarow);
+            }
+
+            return newDataTable;
+        }
+    }
+}

--- a/core/Measurement.cs
+++ b/core/Measurement.cs
@@ -14,6 +14,13 @@ namespace CTP.core
         private DataTable _table = new();
         public double MaxValue = 10;
         public double MinValue = 0;
+
+        
+        public double MinTime = 0;
+        public double MaxTime = 0;
+
+        public int AmtOfRows = 0;
+
         public Measurements() { }
 
         private static Measurements? _instance;
@@ -28,9 +35,15 @@ namespace CTP.core
         {
             _table = Table;
 
+            AmtOfRows = ValueCount();
+
+            MinTime = _table.Rows[1].Field<double>(0);
+            MaxTime = _table.Rows[AmtOfRows-1].Field<double>(0);
+
             foreach (DataRow Row in _table.Rows)
             {
                 double value = Row.Field<double>(1);
+
                 if (value > MaxValue) MaxValue = value;
                 else if(value < MinValue) MinValue = value;
             }
@@ -38,7 +51,7 @@ namespace CTP.core
 
         public double? ReadValue(int index, int col = 1)
         {
-            if (_table == null || index >= ValueCount()) return null;
+            if (_table == null || index >= AmtOfRows) return null;
 
             return _table.Rows[index].Field<double>(col);
         }

--- a/core/RealTimeChart.cs
+++ b/core/RealTimeChart.cs
@@ -16,7 +16,8 @@ public partial class ViewModel : ObservableObject
     private readonly List<DateTimePoint> _values2 = new();
     private readonly DateTimeAxis _customAxis;
     private readonly Measurements _data = Measurements.GetInstance();
-    private int _visibleElements = 250;
+
+    public int _visibleElements { get; set; } = 250;
 
     public ViewModel()
     {


### PR DESCRIPTION
Dodałem klasę **DataScaler**, ze statyczną funkcją **ScaleData(DataTable dt, int TargetDatapoints=250).**

Skaluje ona dowolnie duży DataTable dt do nowego DataTable o ilości rzędów = TargetDatapoints.
Dzięki temu cały kształt wykresu jest widoczny w oknie aplikacji.

Póki co tracimy do TargetDatapoints-1 punktów oryginalnych danych (trzeba uwzględnić resztę po podziale danych), kod jest do refaktoryzacji/ulepszenia ale ma swoją zasadniczą funkcjonalność. 

TargetDatapoints powinien być równy atrybutowi **_visibleElements** klasy **ViewModel** z **RealTimeChart.cs**, aby wykres się w oknie nie powtarzał, a także żeby było go widać w całości.

